### PR TITLE
chore(goreleaser): `replacements`の廃止に対応

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,12 +16,12 @@ builds:
       - -X github.com/arrow2nd/nekome/v2/api.consumerSecret={{.Env.CONSUMER_SECRET}}
 
 archives:
-  - replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      386: i386
-      amd64: x86_64
+  - name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
     format_overrides:
       - goos: windows
         format: zip


### PR DESCRIPTION
ref: https://goreleaser.com/deprecations/#archivesreplacements
